### PR TITLE
Add release publication workflow (fixes #3)

### DIFF
--- a/.github/workflows/release-publisher.yml
+++ b/.github/workflows/release-publisher.yml
@@ -1,0 +1,23 @@
+name: Publish release binaries
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@master
+      - name: Build
+        uses: ngalaiko/bazel-action@0.29.0
+        with:
+          args: build //...
+      - name: Upload release binaries
+        uses: skx/github-action-publish-binaries@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          version: latest
+          args: bazel-bin/lambda_deploy.zip


### PR DESCRIPTION
The goreleaser action is great, but it wants to run the go builds internally, and we are using bazel.

Found https://github.com/marketplace/actions/github-action-publish-binaries which just uploads a file pattern instead.