### PR TITLE
update syncdeps to run gazelle for new vendored packages

### DIFF
--- a/scripts/syncdeps.sh
+++ b/scripts/syncdeps.sh
@@ -11,7 +11,12 @@ command -v go
 echo "$gazelle"
 
 cd "$BUILD_WORKSPACE_DIRECTORY"
+# this makes it easy to confirm we are running go from the bazel toolchain
 go version
 go mod tidy
+# mod vendor will vendor any new or changed deps
 go mod vendor
+# after we have new packages in vendor, run gazelle to generate BUILD files
+$gazelle
+# also run gazelle update-repos to fix the go_repositories rules in WORKSPACE to match go.mod
 $gazelle update-repos -from_file=go.mod


### PR DESCRIPTION
without this fix, newly vendored packages did not have a generated BUILD file and the bazel build failed.