### PR TITLE
Don't use rules_pkg right now

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
-load("@rules_pkg//pkg:pkg.bzl", "pkg_zip")
 load("@bazel_gazelle//:def.bzl", "gazelle")
 
 # gazelle:prefix github.com/kindlyops/pipeline-monitor
@@ -39,15 +38,15 @@ go_binary(
     visibility = ["//visibility:private"],
 )
 
-pkg_zip(
-    name = "lambda_deploy",
-    srcs = [
-        ":pipelinemonitor",
-    ],
-    build_zip = "@rules_pkg//pkg:build_zip",
-    timestamp = 0,
-    visibility = ["//visibility:public"],
-)
+# TODO: rework this to make a zip with execute bit set on binary
+# pkg_zip(
+#     name = "lambda_deploy",
+#     srcs = [
+#         ":pipelinemonitor",
+#     ],
+#     timestamp = 0,
+#     visibility = ["//visibility:public"],
+# )
 
 go_test(
     name = "go_default_test",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,14 +48,6 @@ http_archive(
     urls = ["https://github.com/bazelbuild/buildtools/archive/{0}.tar.gz".format(buildtools_version)],
 )
 
-# https://github.com/bazelbuild/rules_pkg/pull/97
-http_archive(
-    name = "rules_pkg",
-    sha256 = "135a94754b05e06d1e6601fb4872ff0df9efa09813fb1bb67e0a40465784ad39",
-    strip_prefix = "rules_pkg-c87df3e066ef3391be21e09534bea153856f707d",
-    urls = ["https://github.com/kindlyops/rules_pkg/archive/c87df3e066ef3391be21e09534bea153856f707d.tar.gz"],
-)
-
 go_repository(
     name = "com_github_aws_aws_sdk_go",
     importpath = "github.com/aws/aws-sdk-go",


### PR DESCRIPTION
Using a forked version of rules_pkg then breaks pkg_tar,
which is used in lots of downstream places, due to https://github.com/bazelbuild/rules_pkg/pull/97

Will have to come up with another solution for getting the execute bit set on the binary inside the zip file, since https://github.com/bazelbuild/rules_pkg/pull/97 is still not merged upstream.